### PR TITLE
Use more flexible types, reduce allocations

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -133,7 +133,7 @@ impl Api {
     }
 
     /// Returns the API url
-    pub fn api_url(&self) -> &String {
+    pub fn api_url(&self) -> &str {
         &self.api_url
     }
 
@@ -258,7 +258,7 @@ impl Api {
     }
 
     /// Turns a Vec of str tuples into a Hashmap of String, to be used in API calls
-    pub fn params_into(&self, params: &Vec<(&str, &str)>) -> HashMap<String, String> {
+    pub fn params_into(&self, params: &[(&str, &str)]) -> HashMap<String, String> {
         params
             .into_iter()
             .map(|tuple| (tuple.0.to_string(), tuple.1.to_string()))
@@ -267,7 +267,7 @@ impl Api {
 
     /// Returns an empty parameter HashMap
     pub fn no_params(&self) -> HashMap<String, String> {
-        self.params_into(&vec![])
+        HashMap::new()
     }
 
     /// Returns a token of a `token_type`, such as `login` or `csrf` (for editing)
@@ -560,7 +560,7 @@ impl Api {
     }
 
     /// Returns the user agent name
-    pub fn user_agent(&self) -> &String {
+    pub fn user_agent(&self) -> &str {
         &self.user_agent
     }
 
@@ -581,7 +581,7 @@ impl Api {
     }
 
     /// Encodes a string
-    fn rawurlencode(&self, s: &String) -> String {
+    fn rawurlencode(&self, s: &str) -> String {
         urlencoding::encode(s)
     }
 
@@ -778,7 +778,7 @@ impl Api {
     /// Used for non-stateless queries, such as logins
     fn query_raw_mut(
         &mut self,
-        api_url: &String,
+        api_url: &str,
         params: &HashMap<String, String>,
         method: &str,
     ) -> Result<String, Box<dyn Error>> {

--- a/src/title.rs
+++ b/src/title.rs
@@ -47,7 +47,7 @@ impl Title {
 
     /// Constructor, where full namespace-prefixed title is known.
     /// Uses Api to parse valid namespaces
-    pub fn new_from_full(full_title: &String, api: &crate::api::Api) -> Self {
+    pub fn new_from_full(full_title: &str, api: &crate::api::Api) -> Self {
         let mut v: Vec<&str> = full_title.split(":").collect();
         if v.len() == 1 {
             return Self::new(&full_title.to_string(), 0);
@@ -152,7 +152,7 @@ impl Title {
     }
 
     /// Returns the non-namespace-prefixed title, with spaces instead of underscores
-    pub fn pretty(&self) -> &String {
+    pub fn pretty(&self) -> &str {
         &self.title // was Title::underscores_to_spaces(&self.title) but always storing without underscores
     }
 
@@ -177,18 +177,18 @@ impl Title {
     }
 
     /// Changes all spaces to underscores
-    pub fn spaces_to_underscores(s: &String) -> String {
+    pub fn spaces_to_underscores(s: &str) -> String {
         s.trim().replace(" ", "_")
     }
 
     /// Changes all underscores to spaces
-    pub fn underscores_to_spaces(s: &String) -> String {
+    pub fn underscores_to_spaces(s: &str) -> String {
         s.replace("_", " ").trim().to_string()
     }
 
     /// Changes the first letter to uppercase.
     /// Enforces spaces instead of underscores.
-    pub fn first_letter_uppercase(s: &String) -> String {
+    pub fn first_letter_uppercase(s: &str) -> String {
         let s = Title::underscores_to_spaces(s);
         let mut c = s.chars();
         match c.next() {

--- a/src/title.rs
+++ b/src/title.rs
@@ -137,12 +137,12 @@ impl Title {
     }
 
     /// Returns the canonical namespace text, based on the Api
-    pub fn namespace_name(&self, api: &crate::api::Api) -> Option<String> {
+    pub fn namespace_name<'a>(&self, api: &'a crate::api::Api) -> Option<&'a str> {
         api.get_canonical_namespace_name(self.namespace_id)
     }
 
     /// Returns the local namespace text, based on the Api
-    pub fn local_namespace_name(&self, api: &crate::api::Api) -> Option<String> {
+    pub fn local_namespace_name<'a>(&self, api: &'a crate::api::Api) -> Option<&'a str> {
         api.get_local_namespace_name(self.namespace_id)
     }
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -116,7 +116,7 @@ impl User {
     }
 
     /// Returns the user name ("" if not logged in)
-    pub fn user_name(&self) -> &String {
+    pub fn user_name(&self) -> &str {
         &self.lgusername
     }
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use std::error::Error;
 
 /// `User` contains the login data for the `Api`
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct User {
     lgusername: String,
     lguserid: u64,
@@ -126,15 +126,15 @@ impl User {
     }
 
     /// Tries to set user information from the `Api` call
-    pub fn set_from_login(&mut self, login: &Value) -> Result<(), String> {
+    pub fn set_from_login(&mut self, login: &Value) -> Result<(), &str> {
         if login["result"] == "Success" {
             match login["lgusername"].as_str() {
                 Some(s) => self.lgusername = s.to_string(),
-                None => return Err("No lgusername in login result".to_string()),
+                None => return Err("No lgusername in login result"),
             }
             match login["lguserid"].as_u64() {
                 Some(u) => self.lguserid = u,
-                None => return Err("No lguserid in login result".to_string()),
+                None => return Err("No lguserid in login result"),
             }
 
             self.is_logged_in = true;


### PR DESCRIPTION
These commits apply a number of best practices.

The first commit replaces `&String` with `&str`, and `&Vec<T>` with`&[T]` where possible because the second is more general, because the first type can be coerced into the second, and doesn't require a memory allocation.

This allows `mediawiki::api::Api::params_into(&[("action", "query"), ("prop", "categories"), ("titles", "Albert Einstein")])`, whereas previously you had to allocate a `Vec` and then pass it as a reference, with `mediawiki::api::Api::params_into(&vec![("action", "query"), ("prop", "categories"), ("titles", "Albert Einstein")])`. The latter will still work because `&Vec<T>` can be coerced into `&[T]`, but the former avoids an unnecessary allocation (and takes four fewer characters).

Similarly, this allows for `mediawiki::api::Api::rawurlencode(api_object, "query")` as well as `mediawiki::api::Api::rawurlencode(api_object, &"query".to_string())`.

Another commit removes unnecessary calls to `clone` and `to_string` methods in various places. The last makes some functions, like `mediawiki::api::Api::get_local_namespace_name`, return a reference, because there is a value to borrow from, and a cloned value can be created easily if needed. (As a bonus `mediawiki::api::Api::get_local_namespace_name` and `mediawiki::api::Api::get_canonical_namespace_name` are shorter and more readable.)

I doubt these changes will have any dramatic performance implications, but they fulfill my desire to neaten things. Some merging is required, but I'm not familiar with how to do that as this is my second pull request ever.