### PR TITLE
Fix query continue parameter handling

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -359,7 +359,8 @@ impl Api {
                 Value::Object(obj) => {
                     cont.clear();
                     obj.iter().filter(|x| x.0 != "continue").for_each(|x| {
-                        cont.insert(x.0.to_string(), x.1.to_string());
+                        let continue_value = x.1.as_str().map_or(x.1.to_string(), |s| s.to_string());
+                        cont.insert(x.0.to_string(), continue_value);
                     });
                 }
                 _ => {


### PR DESCRIPTION
The .to_string() function was being used on a JSON value, which meant values that were already strings would get an extra layer of "" around them. As a result, the continue values would be incorrect and the API would sometimes yield a Wikimedia\Timestamp\TimestampException when it encountered the double-quote at the beginning of the (for example) rccontinue parameter

Before this PR, API queries would be unable to be continued, resulting in only the first page of queries being returned.