### PR TITLE
Iterator version of get_query_api_json_limit

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -386,10 +386,8 @@ impl Api {
                         self.continue_params = result["continue"].clone();
                         if self.continue_params.is_null() {
                             self.values_remaining = Some(0);
-                        } else {
-                            if let Some(num) = self.values_remaining {
-                                self.values_remaining = Some(num.wrapping_sub(self.api.query_result_count(&result)));
-                            }
+                        } else if let Some(num) = self.values_remaining {
+                            self.values_remaining = Some(num.wrapping_sub(self.api.query_result_count(&result)));
                         }
                         result.as_object_mut().map(|r| r.remove("continue"));
                         Ok(result)

--- a/src/api.rs
+++ b/src/api.rs
@@ -323,7 +323,7 @@ impl Api {
     }
 
     /// Tries to return the len() of an API query result. Returns 0 if unknown
-    pub fn query_result_count(&self, result: &Value) -> usize {
+    fn query_result_count(&self, result: &Value) -> usize {
         match result["query"].as_object() {
             Some(query) => query
                 .iter()


### PR DESCRIPTION
Design notes:
- I made get_query_api_json_limit return `impl Iterator` instead of `ApiQuery<'a>`. I figured this made the signature look a bit cleaner, but I'm equally fine with either way.
- Overloading `values_remaining` as a flag for "done" is efficient but ugly. I can introduce a boolean flag for this if you want.
- I'm very unattached to any of the names introduced in this PR. "get_query_api_json_limit_iter" seems pretty unwieldy but I can't think of a shorter alternative.

I haven't really tested this, but I've been using it in a bot and it seems to be working fine enough. I could put in a test using some query; I would prefer mocking a reqwest client to avoid calling the live API, but that's probably for another PR.