### PR TITLE
Fix infinite loop in query iterator

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -387,7 +387,7 @@ impl Api {
                         if self.continue_params.is_null() {
                             self.values_remaining = Some(0);
                         } else if let Some(num) = self.values_remaining {
-                            self.values_remaining = Some(num.wrapping_sub(self.api.query_result_count(&result)));
+                            self.values_remaining = Some(num.saturating_sub(self.api.query_result_count(&result)));
                         }
                         result.as_object_mut().map(|r| r.remove("continue"));
                         Ok(result)


### PR DESCRIPTION
wrapping_sub, as the name suggests, wraps around to the maximum value of usize. I intended to use saturating_sub, which stops when it hits 0. Very sorry about that.