### PR TITLE
Bugfix for "return references" commit

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -208,41 +208,25 @@ impl Api {
         }
     }
 
+
     /// Returns the raw data for the namespace, matching `["query"]["namespaces"][namespace_id]`
-    pub fn get_namespace_value(&self, namespace_id: NamespaceID) -> Option<&Value> {
-        let v = self.get_site_info_value("namespaces", format!("{}", namespace_id).as_str());
-        if v.is_object() {
-            Some(v)
-        } else {
-            None
-        }
+    pub fn get_namespace_info(&self, namespace_id: NamespaceID) -> &Value {
+        self.get_site_info_value("namespaces", &namespace_id.to_string())
     }
 
     /// Returns the canonical namespace name for a namespace ID, if defined
-    pub fn get_canonical_namespace_name<'a>(
-        &'a self,
+    pub fn get_canonical_namespace_name(
+        &self,
         namespace_id: NamespaceID,
-    ) -> Option<&'a str> {
-        let v = self.get_namespace_value(namespace_id)?;
-        match v["canonical"].as_str() {
-            Some(name) => Some(name),
-            None => match v["*"].as_str() {
-                Some(name) => Some(name),
-                None => None,
-            },
-        }
+    ) -> Option<&str> {
+        let info = self.get_namespace_info(namespace_id);
+        info["canonical"].as_str().or_else(|| info["*"].as_str())
     }
 
     /// Returns the local namespace name for a namespace ID, if defined
-    pub fn get_local_namespace_name<'a>(&'a self, namespace_id: NamespaceID) -> Option<&'a str> {
-        let v = self.get_namespace_value(namespace_id)?;
-        match v["*"].as_str() {
-            Some(name) => Some(name),
-            None => match v["canonical"].as_str() {
-                Some(name) => Some(name),
-                None => None,
-            },
-        }
+    pub fn get_local_namespace_name(&self, namespace_id: NamespaceID) -> Option<&str> {
+        let info = self.get_namespace_info(namespace_id);
+        info["*"].as_str().or_else(|| info["canonical"].as_str())
     }
 
     /// Loads the site info.

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -242,7 +242,7 @@ fn main() {
     */
 
     let api = mediawiki::api::Api::new("https://www.wikidata.org/w/api.php").unwrap();
-    let x = api.get_namespace_value(0);
+    let x = api.get_namespace_info(0);
     println!("{:?}", x);
     let x = api.get_local_namespace_name(0);
     println!("{:?}", x);


### PR DESCRIPTION
This is intended to improve on dc4055e5b4c34a12e1953a7b782c4920a0897698 as a bugfix for 0859d97a1e376f791bc79ab9ad5a1e9a6577daf3, in which `get_canonical_namespace_name` and `get_local_namespace_name` will panic when the namespace id was not found. The nice `Option::or_else` method makes the code more readable. (Clippy recommended it over the `Option::or` used in the original buggy commit even though it probably doesn't matter for performance.)