### PR TITLE
Pin time dependency to 0.2.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ authors = ["Magnus Manske <magnusmanske@googlemail.com>"]
 edition = "2018"
 
 [dependencies]
+time = "=0.2.7"
 serde_json = "1"
 reqwest = { version = "0.10", features = ["blocking", "json"] }
 user_agent = "0.9"


### PR DESCRIPTION
Closes #20 

Builds successfully, otherwise not tested.