### PR TITLE
Use nanoid instead of uuid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ urlencoding = "1"
 config = "0.10"
 cookie = "0.13"
 lazy_static = "1.4"
-uuid = { version = "0.8", features = ["v4"] }
+nanoid = "0.3.0"
 url = "2.1"
 base64 = "0.11"
 hmac = "0.7.1"

--- a/src/api.rs
+++ b/src/api.rs
@@ -19,6 +19,7 @@ extern crate cookie;
 extern crate hmac;
 extern crate reqwest;
 extern crate sha1;
+extern crate nanoid;
 
 use crate::api::hmac::Mac;
 use crate::title::Title;
@@ -33,7 +34,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use std::{thread, time};
 use url::Url;
 use urlencoding;
-use uuid::Uuid;
+use nanoid::nanoid;
 
 /// Alias for a namespace (could be -1 for Special pages etc.)
 pub type NamespaceID = i64;
@@ -716,7 +717,7 @@ impl Api {
             .as_secs()
             .to_string();
 
-        let nonce = Uuid::new_v4().to_simple().to_string();
+        let nonce = nanoid!(10);
 
         let mut headers = HeaderMap::new();
 


### PR DESCRIPTION
Lesser crates required and has a simple functionality.