### PR TITLE
Use gitignore instead of cargo's exclude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+target
+doc
+Cargo.lock
+.cargo
+.DS_Store
+*/.DS_Store
+*.ini
+*.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ keywords = ["MediaWiki","API"]
 categories = ["api-bindings","authentication"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/magnusmanske/mediawiki_rust"
-exclude = [".DS_Store","*/.DS_Store","*.ini",".gitignore","*.json"]
 version = "0.1.28"
 authors = ["Magnus Manske <magnusmanske@googlemail.com>"]
 edition = "2018"


### PR DESCRIPTION
target and debug files take a lot of time for git to enumerate and compress, better for git to simply ignore the files.