### PR TITLE
Move lazy_static to dev, prune test config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,11 @@ user_agent = "0.9"
 urlencoding = "1"
 config = "0.10"
 cookie = "0.13"
-lazy_static = "1.4"
 nanoid = "0.3.0"
 url = "2.1"
 base64 = "0.11"
 hmac = "0.7.1"
 sha-1 = "0.8.2"
+
+[dev-dependencies]
+lazy_static = "1.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-#[macro_use]
+#[cfg(test)] #[macro_use]
 extern crate lazy_static;
-#[macro_use]
+#[cfg(test)] #[macro_use]
 extern crate serde_json;
 
 pub use reqwest;
@@ -10,6 +10,7 @@ pub mod page;
 pub mod title;
 pub mod user;
 
+#[cfg(test)]
 lazy_static! {
     static ref JUSTIFY_LAZY_STATIC_MACRO_USE: u8 = 0;
     static ref JUSTIFY_SERDE_JSON_MACRO_USE: serde_json::Value = json!("");

--- a/src/page.rs
+++ b/src/page.rs
@@ -14,8 +14,6 @@ The `Page` class deals with operations done on pages, like editing.
     unused_qualifications
 )]
 
-extern crate lazy_static;
-
 use crate::api::Api;
 use crate::title::Title;
 use serde_json::Value;

--- a/src/title.rs
+++ b/src/title.rs
@@ -14,8 +14,6 @@ The `Title` class deals with page titles and namespaces
     unused_qualifications
 )]
 
-extern crate lazy_static;
-
 use std::hash::{Hash, Hasher};
 
 /// Shortcut for crate::api::NamespaceID


### PR DESCRIPTION
lazy_static is only used in tests and should ideally be removed from default dependencies, `extern crate` is no longer required, passes tests but I might be getting a few things wrong (still learning).