### PR TITLE
Use reqwest's built-in cookie handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,9 @@ edition = "2018"
 [dependencies]
 time = "=0.2.7"
 serde_json = "1"
-reqwest = { version = "0.10", features = ["blocking", "json"] }
-user_agent = "0.9"
+reqwest = { version = "0.10", features = ["blocking","cookies", "json"] }
 urlencoding = "1"
 config = "0.10"
-cookie = "0.13"
 nanoid = "0.3.0"
 url = "2.1"
 base64 = "0.11"


### PR DESCRIPTION
According to the user_agent documentation, reqwest has its own cookie
handling since 0.9.14. Enabling the "cookies" feature and toggling it in
the builder allows us to remove all of the manual cookie handling.

Plus this lets us drop the user_agent (which looked unused) and cookie
dependencies.

Note: I only tested this using the normal login procedures, not with OAuth.