### PR TITLE
Support authenticating with an OAuth2 access token

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ authors = ["Magnus Manske <magnusmanske@googlemail.com>"]
 edition = "2018"
 
 [dependencies]
-time = "=0.2.7"
 serde_json = "1"
 tokio = { version = "^0.2", features = ["macros"] }
 reqwest = { version = "0.10", features = ["blocking", "json"] }


### PR DESCRIPTION
All that's needed is passing an `Authorization: Bearer <token>` header with
any API request.

See <https://www.mediawiki.org/wiki/OAuth/For_Developers#Making_requests_on_the_user's_behalf_2>.

----

cc @enterprisey 