### PR TITLE
Add example for the Api new functions

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -101,6 +101,14 @@ pub struct Api {
 impl Api {
     /// Returns a new `Api` element, and loads the MediaWiki site info from the `api_url` site.
     /// This is done both to get basic information about the site, and to test the API.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+    /// let api = mediawiki::api::Api::new("https://en.wikipedia.org/w/api.php").await.unwrap();
+    /// # });
+    /// ```
     pub async fn new(api_url: &str) -> Result<Api, Box<dyn Error>> {
         Api::new_from_builder(api_url, reqwest::Client::builder()).await
     }

--- a/src/api_sync.rs
+++ b/src/api_sync.rs
@@ -63,6 +63,12 @@ pub struct ApiSync {
 impl ApiSync {
     /// Returns a new `ApiSync` element, and loads the MediaWiki site info from the `api_url` site.
     /// This is done both to get basic information about the site, and to test the API.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let api = mediawiki::api_sync::ApiSync::new("https://en.wikipedia.org/w/api.php").unwrap();
+    /// ```
     pub fn new(api_url: &str) -> Result<ApiSync, Box<dyn Error>> {
         ApiSync::new_from_builder(api_url, reqwest::blocking::Client::builder())
     }


### PR DESCRIPTION
Mostly useful as an example for what sort of URL should be passed in. I forget every time and have to look it up in the library's readme.