### PR TITLE
Use reqwest's built-in cookie handling in api_sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,8 @@ edition = "2018"
 serde_json = "1"
 tokio = { version = "^0.2", features = ["macros"] }
 reqwest = { version = "^0.10", features = ["blocking", "cookies", "json"] }
-user_agent = "0.11"
 urlencoding = "1"
 config = "0.10"
-cookie = "0.13"
 nanoid = "0.3"
 url = "2.1"
 base64 = "0.12"

--- a/src/api_sync.rs
+++ b/src/api_sync.rs
@@ -16,7 +16,6 @@ This sync version is kept for backwards compatablilty.
 )]
 
 extern crate base64;
-extern crate cookie;
 extern crate hmac;
 extern crate reqwest;
 extern crate sha1;
@@ -25,7 +24,6 @@ use crate::api::OAuthParams;
 use crate::hmac::Mac;
 use crate::title::Title;
 use crate::user::User;
-use cookie::{Cookie, CookieJar};
 use nanoid::nanoid;
 use reqwest::header::{HeaderMap, HeaderValue};
 use serde_json::Value;
@@ -51,7 +49,6 @@ pub struct ApiSync {
     api_url: String,
     site_info: Value,
     client: reqwest::blocking::Client,
-    cookie_jar: CookieJar,
     user: User,
     user_agent: String,
     maxlag_seconds: Option<u64>,
@@ -77,8 +74,7 @@ impl ApiSync {
         let mut ret = ApiSync {
             api_url: api_url.to_string(),
             site_info: serde_json::from_str(r"{}")?,
-            client: builder.build()?,
-            cookie_jar: CookieJar::new(),
+            client: builder.cookie_store(true).build()?,
             user: User::new(),
             user_agent: DEFAULT_USER_AGENT.to_string(),
             maxlag_seconds: DEFAULT_MAXLAG,
@@ -498,33 +494,6 @@ impl ApiSync {
         self.query_api_json_mut(params, "POST")
     }
 
-    /// Adds or replaces cookies in the cookie jar from a http `Response`
-    pub fn set_cookies_from_response(&mut self, resp: &reqwest::blocking::Response) {
-        let cookie_strings = resp
-            .headers()
-            .get_all(reqwest::header::SET_COOKIE)
-            .iter()
-            .filter_map(|v| match v.to_str() {
-                Ok(x) => Some(x.to_string()),
-                Err(_) => None,
-            })
-            .collect::<Vec<String>>();
-        for cs in cookie_strings {
-            if let Ok(cookie) = Cookie::parse(cs.clone()) {
-                self.cookie_jar.add(cookie);
-            }
-        }
-    }
-
-    /// Generates a single string to pass as COOKIE parameter in a http `Request`
-    pub fn cookies_to_string(&self) -> String {
-        self.cookie_jar
-            .iter()
-            .map(|c| c.to_string())
-            .collect::<Vec<String>>()
-            .join("; ")
-    }
-
     /// Runs a query against the MediaWiki API, and returns a text.
     /// Uses `query_raw`
     pub fn query_api_raw(
@@ -699,7 +668,6 @@ impl ApiSync {
             reqwest::header::AUTHORIZATION,
             HeaderValue::from_str(header.as_str())?,
         );
-        headers.insert(reqwest::header::COOKIE, self.cookies_to_string().parse()?);
         headers.insert(reqwest::header::USER_AGENT, self.user_agent_full().parse()?);
 
         match method {
@@ -725,13 +693,11 @@ impl ApiSync {
             "GET" => self
                 .client
                 .get(api_url)
-                .header(reqwest::header::COOKIE, self.cookies_to_string())
                 .header(reqwest::header::USER_AGENT, self.user_agent_full())
                 .query(&params),
             "POST" => self
                 .client
                 .post(api_url)
-                .header(reqwest::header::COOKIE, self.cookies_to_string())
                 .header(reqwest::header::USER_AGENT, self.user_agent_full())
                 .form(&params),
             other => return Err(From::from(format!("Unsupported method '{}'", other))),
@@ -768,7 +734,6 @@ impl ApiSync {
         method: &str,
     ) -> Result<String, Box<dyn Error>> {
         let resp = self.query_raw_response(api_url, params, method)?;
-        self.set_cookies_from_response(&resp);
         Ok(resp.text()?)
     }
 


### PR DESCRIPTION
Same as #27 but for the new api_sync module.