### PR TITLE
fix typos in comments and strings

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,5 @@
 /*!
-The `Api` class serves as a univeral interface to a MediaWiki API.
+The `Api` class serves as a universal interface to a MediaWiki API.
 */
 
 #![deny(
@@ -490,7 +490,7 @@ impl Api {
         true
     }
 
-    /// Sets the maglag parameter for a query, if necessary
+    /// Sets the maxlag parameter for a query, if necessary
     fn _set_maxlag_params(&self, params: &mut HashMap<String, String>, method: &str) {
         if !self.is_edit_query(params, method) {
             return;
@@ -500,7 +500,7 @@ impl Api {
         }
     }
 
-    /// Sets the maglag parameter for a query, if necessary
+    /// Sets the maxlag parameter for a query, if necessary
     fn set_cumulative_maxlag_params(
         &self,
         params: &mut HashMap<String, String>,
@@ -516,7 +516,7 @@ impl Api {
         }
     }
 
-    /// Checks for a MAGLAG error, and returns the lag if so
+    /// Checks for a maxlag error, and returns the lag if so
     fn check_maxlag(&self, v: &Value) -> Option<u64> {
         match v["error"]["code"].as_str() {
             Some(code) => match code {
@@ -544,7 +544,7 @@ impl Api {
     }
 
     /// POST wrapper for `query_api_json`.
-    /// Requires `&mut self`, for sassion cookie storage
+    /// Requires `&mut self`, for session cookie storage
     pub async fn post_query_api_json_mut(
         &mut self,
         params: &HashMap<String, String>,
@@ -686,14 +686,14 @@ impl Api {
             "oauth_consumer_key",
             oauth.g_consumer_key
                 .as_ref()
-                .ok_or("Falied to get ref for oauth_consumer_key")?
+                .ok_or("Failed to get ref for oauth_consumer_key")?
                 .parse()?,
         );
         headers.insert(
             "oauth_token", 
             oauth.g_token_key
             .as_ref()
-            .ok_or("Falied to get ref for g_token_key")?
+            .ok_or("Failed to get ref for g_token_key")?
             .parse()?
         );
         headers.insert("oauth_version", "1.0".parse()?);

--- a/src/api_sync.rs
+++ b/src/api_sync.rs
@@ -1,6 +1,6 @@
 /*!
-The `ApiSync` class serves as a univeral interface to a MediaWiki API.
-This sync version is kept for backwards compatablilty.
+The `ApiSync` class serves as a universal interface to a MediaWiki API.
+This sync version is kept for backwards compatibility.
 */
 
 #![deny(
@@ -438,7 +438,7 @@ impl ApiSync {
         true
     }
 
-    /// Sets the maglag parameter for a query, if necessary
+    /// Sets the maxlag parameter for a query, if necessary
     fn _set_maxlag_params(&self, params: &mut HashMap<String, String>, method: &str) {
         if !self.is_edit_query(params, method) {
             return;
@@ -448,7 +448,7 @@ impl ApiSync {
         }
     }
 
-    /// Sets the maglag parameter for a query, if necessary
+    /// Sets the maxlag parameter for a query, if necessary
     fn set_cumulative_maxlag_params(
         &self,
         params: &mut HashMap<String, String>,
@@ -464,7 +464,7 @@ impl ApiSync {
         }
     }
 
-    /// Checks for a MAGLAG error, and returns the lag if so
+    /// Checks for a maxlag error, and returns the lag if so
     fn check_maxlag(&self, v: &Value) -> Option<u64> {
         match v["error"]["code"].as_str() {
             Some(code) => match code {

--- a/src/user.rs
+++ b/src/user.rs
@@ -46,7 +46,7 @@ impl User {
         self.user_info.is_some()
     }
 
-    /// Checks is the user has a spefic right (e.g. "bot", "autocinfirmed")
+    /// Checks is the user has a specific right (e.g. "bot", "autoconfirmed")
     pub fn has_right(&self, right: &str) -> bool {
         match &self.user_info {
             Some(ui) => {


### PR DESCRIPTION
Mostly found by the IntelliJ plugin.