### PR TITLE
Pass md5 hash when editing for additional integrity protection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ nanoid = "^0.3"
 url = "^2.2"
 base64 = "^0.13"
 hmac = "^0.10.1"
+md5 = "^0.7.0"
 sha2 = "^0.9.2"
 
 [dev-dependencies]

--- a/src/page.rs
+++ b/src/page.rs
@@ -112,13 +112,16 @@ impl Page {
             .full_pretty(api)
             .ok_or_else(|| PageError::BadTitle(self.title.clone()))?;
         let bot = if api.user().is_bot() { "true" } else { "false" };
+        let text = text.into();
+        let checksum = format!("{:x}", md5::compute(&text));
         let mut params: HashMap<String, String> = [
             ("action", "edit"),
             ("title", &title),
-            ("text", &text.into()),
+            ("text", &text),
             ("summary", &summary.into()),
             ("bot", bot),
             ("formatversion", "2"),
+            ("md5", &checksum),
             ("token", &api.get_edit_token().await?),
         ]
         .iter()


### PR DESCRIPTION
Part of #42.