### PR TITLE
Remove the unneeded `unsafe`

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2,17 +2,7 @@
 The `Api` class serves as a universal interface to a MediaWiki API.
 */
 
-#![deny(
-    missing_docs,
-    missing_debug_implementations,
-    missing_copy_implementations,
-    //trivial_casts,
-    trivial_numeric_casts,
-    //unsafe_code,
-    unstable_features,
-    unused_import_braces,
-    unused_qualifications
-)]
+#![deny(missing_docs)]
 
 extern crate base64;
 extern crate nanoid;

--- a/src/api_sync.rs
+++ b/src/api_sync.rs
@@ -3,17 +3,7 @@ The `ApiSync` class serves as a universal interface to a MediaWiki API.
 This sync version is kept for backwards compatibility.
 */
 
-#![deny(
-    missing_docs,
-    missing_debug_implementations,
-    missing_copy_implementations,
-    trivial_casts,
-    trivial_numeric_casts,
-    unsafe_code,
-    unstable_features,
-    unused_import_braces,
-    unused_qualifications
-)]
+#![deny(missing_docs)]
 
 extern crate base64;
 extern crate hmac;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,15 @@
+#![deny(
+    // missing_docs,
+    missing_debug_implementations,
+    missing_copy_implementations,
+    trivial_casts,
+    trivial_numeric_casts,
+    unsafe_code,
+    unstable_features,
+    unused_import_braces,
+    unused_qualifications
+)]
+
 #[cfg(test)]
 extern crate lazy_static;
 #[cfg(test)]

--- a/src/media_wiki_error.rs
+++ b/src/media_wiki_error.rs
@@ -13,7 +13,6 @@ pub enum MediaWikiError {
 }
 
 impl Error for MediaWikiError {}
-unsafe impl Send for MediaWikiError {}
 
 impl fmt::Display for MediaWikiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/page.rs
+++ b/src/page.rs
@@ -2,17 +2,7 @@
 The `Page` class deals with operations done on pages, like editing.
 */
 
-#![deny(
-    missing_docs,
-    missing_debug_implementations,
-    missing_copy_implementations,
-    trivial_casts,
-    trivial_numeric_casts,
-    unsafe_code,
-    unstable_features,
-    unused_import_braces,
-    unused_qualifications
-)]
+#![deny(missing_docs)]
 
 use crate::media_wiki_error::MediaWikiError;
 use crate::api::Api;

--- a/src/title.rs
+++ b/src/title.rs
@@ -2,17 +2,7 @@
 The `Title` class deals with page titles and namespaces
 */
 
-#![deny(
-    missing_docs,
-    missing_debug_implementations,
-    missing_copy_implementations,
-    trivial_casts,
-    trivial_numeric_casts,
-    unsafe_code,
-    unstable_features,
-    unused_import_braces,
-    unused_qualifications
-)]
+#![deny(missing_docs)]
 
 /// Shortcut for crate::api::NamespaceID
 type NamespaceID = crate::api::NamespaceID;

--- a/src/user.rs
+++ b/src/user.rs
@@ -2,17 +2,7 @@
 The `User` class deals with the (current) ApiSync user.
 */
 
-#![deny(
-    missing_docs,
-    missing_debug_implementations,
-    missing_copy_implementations,
-    trivial_casts,
-    trivial_numeric_casts,
-    unsafe_code,
-    unstable_features,
-    unused_import_braces,
-    unused_qualifications
-)]
+#![deny(missing_docs)]
 
 use serde_json::Value;
 


### PR DESCRIPTION
Remove the unneeded `unsafe`, and move the enforcement lints to lib.rs

MediawikiError is Send already.

Unsafely declaring it to be Send without any "//SAFETY:" comment justifiing the soundness is scary. So let's not.

With this change in place the lib can now boast having `#![deny(unsafe_code)]` at the root, and an approval of `cargo geiger` :P 