### PR TITLE
Change first example to api_sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Get all categories of "Albert Einstein" on English Wikipedia
 ```rust
-let mut api = mediawiki::api::Api::new("https://en.wikipedia.org/w/api.php").unwrap();
+let api = mediawiki::api_sync::ApiSync::new("https://en.wikipedia.org/w/api.php").unwrap();
 
 // Query parameters
 let params = api.params_into(&[


### PR DESCRIPTION
Since async is the default now, the first example will not work without adding awaits. Instead, change it to `api_sync::ApiSync`. Also, `api` does not need to be `mut`.