### PR TITLE
Implement case folding as in MediaWiki

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ url = "^2.5"
 base64 = "^0.22"
 hmac = "^0.12"
 sha1 = "^0.10"
+unicode-case-mapping = "^0.5"
 
 [dev-dependencies]
 lazy_static = "^1.4"

--- a/src/title.rs
+++ b/src/title.rs
@@ -185,7 +185,17 @@ impl Title {
         let mut c = s.chars();
         match c.next() {
             None => String::new(),
-            Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+            Some(f) => {
+                let f = unicode_case_mapping::to_titlecase(f);
+                if f[0] == 0 {
+                    s
+                } else {
+                    f.into_iter()
+                        .filter_map(|c| if c != 0 { char::from_u32(c) } else { None })
+                        .collect::<String>()
+                        + c.as_str()
+                }
+            }
         }
     }
 
@@ -317,6 +327,7 @@ mod tests {
         assert_eq!(Title::first_letter_uppercase(&"FooBar"), "FooBar");
         assert_eq!(Title::first_letter_uppercase(&"fooBar"), "FooBar");
         assert_eq!(Title::first_letter_uppercase(&"über"), "Über");
+        assert_eq!(Title::first_letter_uppercase(&"ვიკიპედია"), "ვიკიპედია");
     }
 
     #[tokio::test]


### PR DESCRIPTION
MediaWiki uses `MB_CASE_TITLE` to convert first letter of article names to uppercase. It preserves the case of the Georgian alphabet.

Source: https://gerrit.wikimedia.org/r/c/mediawiki/core/+/842028