### PR TITLE
chore: add links to referenced items

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,5 @@
 /*!
-The `Api` class serves as a universal interface to a MediaWiki API.
+The [`Api`] class serves as a universal interface to a MediaWiki API.
 */
 
 #![deny(missing_docs)]
@@ -30,7 +30,7 @@ const DEFAULT_DELAY_FOR_TOO_MANY_REQUESTS: u64 = 30;
 
 type HmacSha1 = Hmac<sha1::Sha1>;
 
-/// `OAuthParams` contains parameters for OAuth requests
+/// [`OAuthParams`] contains parameters for OAuth requests
 #[derive(Debug, Clone)]
 pub struct OAuthParams {
     /// Consumer Key
@@ -71,7 +71,7 @@ impl OAuthParams {
     }
 }
 
-/// `Api` is the main class to interact with a MediaWiki API
+/// [`Api`] is the main class to interact with a MediaWiki API
 #[derive(Debug, Clone)]
 pub struct Api {
     api_url: String,
@@ -87,7 +87,7 @@ pub struct Api {
 }
 
 impl Api {
-    /// Returns a new `Api` element, and loads the MediaWiki site info from the `api_url` site.
+    /// Returns a new [`Api`] element, and loads the MediaWiki site info from the `api_url` site.
     /// This is done both to get basic information about the site, and to test the API.
     ///
     /// # Examples
@@ -101,7 +101,7 @@ impl Api {
         Api::new_from_builder(api_url, reqwest::Client::builder().timeout(DEFAULT_TIMEOUT)).await
     }
 
-    /// Returns a new `Api` element, and loads the MediaWiki site info from the `api_url` site.
+    /// Returns a new [`Api`] element, and loads the MediaWiki site info from the `api_url` site.
     /// This is done both to get basic information about the site, and to test the API.
     /// Uses a bespoke reqwest::ClientBuilder.
     pub async fn new_from_builder(
@@ -225,7 +225,7 @@ impl Api {
     }
 
     /// Loads the site info.
-    /// Should only ever be called from `new()`
+    /// Should only ever be called from [`new`][Self::new]
     async fn load_site_info(&mut self) -> Result<&Value, MediaWikiError> {
         let params = hashmap!["action".to_string()=>"query".to_string(),"meta".to_string()=>"siteinfo".to_string(),"siprop".to_string()=>"general|namespaces|namespacealiases|libraries|extensions|statistics".to_string()];
         self.site_info = self.get_query_api_json(&params).await?;
@@ -286,12 +286,12 @@ impl Api {
         }
     }
 
-    /// Calls `get_token()` to return an edit token
+    /// Calls [`get_token`][`Api::get_token`] to return an edit token
     pub async fn get_edit_token(&mut self) -> Result<String, MediaWikiError> {
         self.get_token("csrf").await
     }
 
-    /// Same as `get_query_api_json` but automatically loads all results via the `continue` parameter
+    /// Same as [`get_query_api_json`][`Api::get_query_api_json`] but automatically loads all results via the `continue` parameter
     pub async fn get_query_api_json_all(
         &self,
         params: &HashMap<String, String>,
@@ -299,7 +299,7 @@ impl Api {
         self.get_query_api_json_limit(params, None).await
     }
 
-    /// Tries to return the len() of an API query result. Returns 0 if unknown
+    /// Tries to return the `len()` of an API query result. Returns 0 if unknown
     fn query_result_count(&self, result: &Value) -> usize {
         match result["query"].as_object() {
             Some(query) => query
@@ -311,7 +311,7 @@ impl Api {
         }
     }
 
-    /// Same as `get_query_api_json` but automatically loads more results via the `continue` parameter
+    /// Same as [`get_query_api_json`][`Api::get_query_api_json`] but automatically loads more results via the `continue` parameter
     pub async fn get_query_api_json_limit(
         &self,
         params: &HashMap<String, String>,
@@ -332,7 +332,7 @@ impl Api {
             .await
     }
 
-    /// Same as `get_query_api_json` but automatically loads more results via the `continue` parameter.
+    /// Same as [`get_query_api_json`][`Api::get_query_api_json`] but automatically loads more results via the `continue` parameter.
     /// Returns a stream; each item is a "page" of results.
     pub async fn get_query_api_json_limit_iter<'a>(
         &'a self,
@@ -461,7 +461,7 @@ impl Api {
         &self.edit_delay_ms
     }
 
-    /// Sets the delay time after edits in milliseconds (or `None`).
+    /// Sets the delay time after edits in milliseconds (or [`None`]).
     /// This is independent of, and additional to, MAXLAG
     pub fn set_edit_delay(&mut self, edit_delay_ms: Option<u64>) {
         self.edit_delay_ms = edit_delay_ms;
@@ -472,7 +472,7 @@ impl Api {
         &self.maxlag_seconds
     }
 
-    /// Sets the maxlag in seconds (or `None`)
+    /// Sets the maxlag in seconds (or [`None`])
     pub fn set_maxlag(&mut self, maxlag_seconds: Option<u64>) {
         self.maxlag_seconds = maxlag_seconds;
     }
@@ -524,7 +524,7 @@ impl Api {
         }
     }
 
-    /// GET wrapper for `query_api_json`
+    /// GET wrapper for [`query_api_json`][`Api::query_api_json`]
     pub async fn get_query_api_json(
         &self,
         params: &HashMap<String, String>,
@@ -532,7 +532,7 @@ impl Api {
         self.query_api_json(params, "GET").await
     }
 
-    /// POST wrapper for `query_api_json`
+    /// POST wrapper for [`query_api_json`][`Api::query_api_json`]
     pub async fn post_query_api_json(
         &self,
         params: &HashMap<String, String>,
@@ -540,7 +540,7 @@ impl Api {
         self.query_api_json(params, "POST").await
     }
 
-    /// POST wrapper for `query_api_json`.
+    /// POST wrapper for [`query_api_json`][`Api::query_api_json`].
     /// Requires `&mut self`, for session cookie storage
     pub async fn post_query_api_json_mut(
         &mut self,
@@ -550,7 +550,7 @@ impl Api {
     }
 
     /// Runs a query against the MediaWiki API, and returns a text.
-    /// Uses `query_raw`
+    /// Uses [`query_raw`][`Api::query_raw`]
     pub async fn query_api_raw(
         &self,
         params: &HashMap<String, String>,
@@ -560,7 +560,7 @@ impl Api {
     }
 
     /// Runs a query against the MediaWiki API, and returns a text.
-    /// Uses `query_raw_mut`
+    /// Uses [`query_raw_mut`][`Api::query_raw_mut`]
     async fn query_api_raw_mut(
         &mut self,
         params: &HashMap<String, String>,
@@ -570,7 +570,7 @@ impl Api {
             .await
     }
 
-    /// Generates a `RequestBuilder` for the API URL
+    /// Generates a [`RequestBuilder`][`reqwest::RequestBuilder`] for the API URL
     pub fn get_api_request_builder(
         &self,
         params: &HashMap<String, String>,
@@ -658,7 +658,7 @@ impl Api {
         Ok(ret)
     }
 
-    /// Returns a signed OAuth POST `RequestBuilder`
+    /// Returns a signed OAuth POST [`RequestBuilder`][`reqwest::RequestBuilder`]
     fn oauth_request_builder(
         &self,
         method: &str,
@@ -746,7 +746,7 @@ impl Api {
         }
     }
 
-    /// Returns a `RequestBuilder` for a generic URL
+    /// Returns a [`RequestBuilder`][`reqwest::RequestBuilder`] for a generic URL
     fn request_builder(
         &self,
         api_url: &str,
@@ -844,7 +844,7 @@ impl Api {
     }
 
     /// Performs a login against the MediaWiki API.
-    /// If successful, user information is stored in `User`, and in the cookie jar
+    /// If successful, user information is stored in [`User`], and in the cookie jar
     pub async fn login<S: Into<String>>(
         &mut self,
         lgname: S,
@@ -863,7 +863,7 @@ impl Api {
         }
     }
 
-    /// From an API result that has a list of entries with "title" and "ns" (e.g. search), returns a vector of `Title` objects.
+    /// From an API result that has a list of entries with "title" and "ns" (e.g. search), returns a vector of [`Title`] objects.
     pub fn result_array_to_titles(data: &Value) -> Vec<Title> {
         // See if it's the "root" of the result, then try each sub-object separately
         if let Some(obj) = data.as_object() {

--- a/src/api_sync.rs
+++ b/src/api_sync.rs
@@ -1,5 +1,5 @@
 /*!
-The `ApiSync` class serves as a universal interface to a MediaWiki API.
+The [`ApiSync`] class serves as a universal interface to a MediaWiki API.
 This sync version is kept for backwards compatibility.
 */
 
@@ -29,7 +29,7 @@ const DEFAULT_MAX_RETRY_ATTEMPTS: u64 = 5;
 
 type HmacSha1 = Hmac<sha1::Sha1>;
 
-/// `ApiSync` is the main class to interact with a MediaWiki API
+/// [`ApiSync`] is the main class to interact with a MediaWiki API
 #[derive(Debug, Clone)]
 pub struct ApiSync {
     api_url: String,
@@ -44,7 +44,7 @@ pub struct ApiSync {
 }
 
 impl ApiSync {
-    /// Returns a new `ApiSync` element, and loads the MediaWiki site info from the `api_url` site.
+    /// Returns a new [`ApiSync`] element, and loads the MediaWiki site info from the `api_url` site.
     /// This is done both to get basic information about the site, and to test the API.
     ///
     /// # Examples
@@ -56,7 +56,7 @@ impl ApiSync {
         ApiSync::new_from_builder(api_url, reqwest::blocking::Client::builder())
     }
 
-    /// Returns a new `ApiSync` element, and loads the MediaWiki site info from the `api_url` site.
+    /// Returns a new [`ApiSync`] element, and loads the MediaWiki site info from the `api_url` site.
     /// This is done both to get basic information about the site, and to test the API.
     /// Uses a bespoke reqwest::ClientBuilder.
     pub fn new_from_builder(
@@ -167,7 +167,7 @@ impl ApiSync {
     }
 
     /// Loads the site info.
-    /// Should only ever be called from `new()`
+    /// Should only ever be called from [`new()`][`Self::new()`]
     fn load_site_info(&mut self) -> Result<&Value, MediaWikiError> {
         let params = hashmap!["action".to_string()=>"query".to_string(),"meta".to_string()=>"siteinfo".to_string(),"siprop".to_string()=>"general|namespaces|namespacealiases|libraries|extensions|statistics".to_string()];
         self.site_info = self.get_query_api_json(&params)?;
@@ -228,12 +228,12 @@ impl ApiSync {
         }
     }
 
-    /// Calls `get_token()` to return an edit token
+    /// Calls [`get_token`][`Self::get_token()`] to return an edit token
     pub fn get_edit_token(&mut self) -> Result<String, MediaWikiError> {
         self.get_token("csrf")
     }
 
-    /// Same as `get_query_api_json` but automatically loads all results via the `continue` parameter
+    /// Same as [`get_query_api_json`][`Self::get_query_api_json`] but automatically loads all results via the `continue` parameter
     pub fn get_query_api_json_all(
         &self,
         params: &HashMap<String, String>,
@@ -253,7 +253,7 @@ impl ApiSync {
         }
     }
 
-    /// Same as `get_query_api_json` but automatically loads more results via the `continue` parameter
+    /// Same as [`get_query_api_json`][`Self::get_query_api_json`] but automatically loads more results via the `continue` parameter
     pub fn get_query_api_json_limit(
         &self,
         params: &HashMap<String, String>,
@@ -266,7 +266,7 @@ impl ApiSync {
             })
     }
 
-    /// Same as `get_query_api_json` but automatically loads more results via the `continue` parameter.
+    /// Same as [`get_query_api_json`][`Self::get_query_api_json`] but automatically loads more results via the `continue` parameter.
     /// Returns an iterator; each item is a "page" of results.
     pub fn get_query_api_json_limit_iter<'a>(
         &'a self,
@@ -396,7 +396,7 @@ impl ApiSync {
         &self.edit_delay_ms
     }
 
-    /// Sets the delay time after edits in milliseconds (or `None`).
+    /// Sets the delay time after edits in milliseconds (or [`None`]).
     /// This is independent of, and additional to, MAXLAG
     pub fn set_edit_delay(&mut self, edit_delay_ms: Option<u64>) {
         self.edit_delay_ms = edit_delay_ms;
@@ -407,7 +407,7 @@ impl ApiSync {
         &self.maxlag_seconds
     }
 
-    /// Sets the maxlag in seconds (or `None`)
+    /// Sets the maxlag in seconds (or [`None`])
     pub fn set_maxlag(&mut self, maxlag_seconds: Option<u64>) {
         self.maxlag_seconds = maxlag_seconds;
     }
@@ -459,7 +459,7 @@ impl ApiSync {
         }
     }
 
-    /// GET wrapper for `query_api_json`
+    /// GET wrapper for [`query_api_json`][`Self::query_api_json`]
     pub fn get_query_api_json(
         &self,
         params: &HashMap<String, String>,
@@ -467,7 +467,7 @@ impl ApiSync {
         self.query_api_json(params, "GET")
     }
 
-    /// POST wrapper for `query_api_json`
+    /// POST wrapper for [`query_api_json`][`Self::query_api_json`]
     pub fn post_query_api_json(
         &self,
         params: &HashMap<String, String>,
@@ -475,7 +475,7 @@ impl ApiSync {
         self.query_api_json(params, "POST")
     }
 
-    /// POST wrapper for `query_api_json`.
+    /// POST wrapper for [`query_api_json`][`Self::query_api_json`].
     /// Requires `&mut self`, for session cookie storage
     pub fn post_query_api_json_mut(
         &mut self,
@@ -485,7 +485,7 @@ impl ApiSync {
     }
 
     /// Runs a query against the MediaWiki API, and returns a text.
-    /// Uses `query_raw`
+    /// Uses [`query_raw`][`Self::query_raw`]
     pub fn query_api_raw(
         &self,
         params: &HashMap<String, String>,
@@ -495,7 +495,7 @@ impl ApiSync {
     }
 
     /// Runs a query against the MediaWiki API, and returns a text.
-    /// Uses `query_raw_mut`
+    /// Uses [`query_raw_mut`][`Self::query_raw_mut`]
     fn query_api_raw_mut(
         &mut self,
         params: &HashMap<String, String>,
@@ -504,7 +504,7 @@ impl ApiSync {
         self.query_raw_mut(&self.api_url.clone(), params, method)
     }
 
-    /// Generates a `RequestBuilder` for the API URL
+    /// Generates a [`RequestBuilder`][`reqwest::RequestBuilder`] for the API URL
     pub fn get_api_request_builder(
         &self,
         params: &HashMap<String, String>,
@@ -592,7 +592,7 @@ impl ApiSync {
         Ok(ret)
     }
 
-    /// Returns a signed OAuth POST `RequestBuilder`
+    /// Returns a signed OAuth POST [`RequestBuilder`][`reqwest::RequestBuilder`]
     fn oauth_request_builder(
         &self,
         method: &str,
@@ -670,7 +670,7 @@ impl ApiSync {
         }
     }
 
-    /// Returns a `RequestBuilder` for a generic URL
+    /// Returns a [`RequestBuilder`][`reqwest::RequestBuilder`] for a generic URL
     fn request_builder(
         &self,
         api_url: &str,
@@ -746,7 +746,7 @@ impl ApiSync {
     }
 
     /// Performs a login against the MediaWiki API.
-    /// If successful, user information is stored in `User`, and in the cookie jar
+    /// If successful, user information is stored in [`User`], and in the cookie jar
     pub fn login<S: Into<String>>(
         &mut self,
         lgname: S,
@@ -765,7 +765,7 @@ impl ApiSync {
         }
     }
 
-    /// From an API result that has a list of entries with "title" and "ns" (e.g. search), returns a vector of `Title` objects.
+    /// From an API result that has a list of entries with "title" and "ns" (e.g. search), returns a vector of [`Title`] objects.
     pub fn result_array_to_titles(data: &Value) -> Vec<Title> {
         // See if it's the "root" of the result, then try each sub-object separately
         if data.is_object() {

--- a/src/media_wiki_error.rs
+++ b/src/media_wiki_error.rs
@@ -13,7 +13,7 @@ pub enum MediaWikiError {
     ReqwestHeader(reqwest::header::InvalidHeaderValue),
     String(String),
     Url(url::ParseError),
-    Fmt(std::fmt::Error),
+    Fmt(fmt::Error),
     Time(std::time::SystemTimeError),
 
     /// Error while logging in.
@@ -105,8 +105,8 @@ impl From<url::ParseError> for MediaWikiError {
     }
 }
 
-impl From<std::fmt::Error> for MediaWikiError {
-    fn from(e: std::fmt::Error) -> Self {
+impl From<fmt::Error> for MediaWikiError {
+    fn from(e: fmt::Error) -> Self {
         Self::Fmt(e)
     }
 }

--- a/src/page.rs
+++ b/src/page.rs
@@ -1,5 +1,5 @@
 /*!
-The `Page` class deals with operations done on pages, like editing.
+The [`Page`] class deals with operations done on pages, like editing.
 */
 
 #![deny(missing_docs)]
@@ -21,7 +21,7 @@ pub struct Page {
 }
 
 impl Page {
-    /// Creates a new `Page` from a `Title`.
+    /// Creates a new [`Page`] from a [`Title`].
     pub fn new(title: Title) -> Self {
         Page {
             title,
@@ -30,22 +30,20 @@ impl Page {
         }
     }
 
-    /// Accesses the `Title` of this `Page`.
+    /// Accesses the [`Title`] of this [`Page`].
     pub fn title(&self) -> &Title {
         &self.title
     }
 
-    /// Fetches the current text of this `Page`. If there is one slot in
+    /// Fetches the current text of this [`Page`]. If there is one slot in
     /// the current revision, it is fetched; if there are multiple slots,
     /// the "main" slot is fetched, or an error is returned if there is
     /// no "main" slot.
     ///
-    /// The `revision` field of this `Page` is set to the fetched revision.
+    /// [`Page`] will cache the fetched revision.
     ///
     /// # Errors
-    /// If the page is missing, will return a `MediaWikiError::Missing`.
-    ///
-    /// [`Api::get_query_api_json`]: ../api/struct.Api.html#method.get_query_api_json
+    /// If the page is missing, will return a [`MediaWikiError::Missing`].
     pub async fn text(&mut self, api: &Api) -> Result<&str, MediaWikiError> {
         let title = self
             .title
@@ -81,13 +79,11 @@ impl Page {
         Ok(wikitext)
     }
 
-    /// Replaces the contents of this `Page` with the given text, using the given
+    /// Replaces the contents of this [`Page`] with the given text, using the given
     /// edit summary.
     ///
     /// # Errors
-    /// May return a `MediaWikiError` or any error from [`Api::post_query_api_json`].
-    ///
-    /// [`Api::post_query_api_json`]: ../api/struct.Api.html#method.post_query_api_json
+    /// May return a [`MediaWikiError`] or any error from [`Api::post_query_api_json`].
     pub async fn edit_text(
         &self,
         api: &mut Api,

--- a/src/revision.rs
+++ b/src/revision.rs
@@ -1,5 +1,5 @@
 /*!
-The `Revision` class deals with page revisions.
+The [`Revision`] class deals with page revisions.
 */
 
 #![deny(missing_docs)]

--- a/src/title.rs
+++ b/src/title.rs
@@ -1,5 +1,5 @@
 /*!
-The `Title` class deals with page titles and namespaces
+The [`Title`] class deals with page titles and namespaces
 */
 
 #![deny(missing_docs)]
@@ -96,7 +96,7 @@ impl Title {
         Self::new(full_title, 0)
     }
 
-    /// Constructor, used internally by `new_from_full`
+    /// Constructor, used internally by [`new_from_full`][`Self::new_from_full`]
     fn new_from_namespace_object(title: String, ns: &serde_json::Value) -> Self {
         let namespace_id = ns["id"].as_i64().unwrap_or_default();
         let title = match ns["case"].as_str() {
@@ -106,7 +106,7 @@ impl Title {
         Self::new(&title, namespace_id)
     }
 
-    /// Constructor, used by ``Api::result_array_to_titles``
+    /// Constructor, used by [`Api::result_array_to_titles`][`crate::Api::result_array_to_titles`]
     pub fn new_from_api_result(data: &serde_json::Value) -> Title {
         let namespace_id = data["ns"].as_i64().unwrap_or(0);
         let mut title = data["title"].as_str().unwrap_or("").to_string();

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,5 +1,5 @@
 /*!
-The `User` class deals with the (current) ApiSync user.
+The [`User`] class deals with the (current) ApiSync user.
 */
 
 #![deny(missing_docs)]
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 use crate::media_wiki_error::MediaWikiError;
 
-/// `User` contains the login data for the `ApiSync`
+/// [`User`] contains the login data for the [`ApiSync`][crate::ApiSync]
 #[derive(Debug, Default, Clone)]
 pub struct User {
     lgusername: String,
@@ -104,7 +104,7 @@ impl User {
         self.lguserid
     }
 
-    /// Tries to set user information from the `ApiSync` call
+    /// Tries to set user information from the [`ApiSync`][crate::ApiSync] call
     pub fn set_from_login(&mut self, login: &Value) -> Result<(), MediaWikiError> {
         if login["result"] == "Success" {
             match login["lgusername"].as_str() {


### PR DESCRIPTION
This mostly adds some brackets to the documentation so `cargo doc` inserts links to the relevant items. Where necessary it also adds the path.